### PR TITLE
Constrain load generator to py37.

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3-slim as base
+FROM python:3.7-slim as base
 
 FROM base as builder
 


### PR DESCRIPTION
This PR constrains the load generator base image to py37 so that there are compatible packages available for the build.